### PR TITLE
markdown_ignore_first

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -10,7 +10,7 @@ endfunction
 function! NestedMarkdownFolds()
   let depth = HeadingDepth(v:lnum)
   if depth > 0
-    return ">".depth
+    return ">".(depth - g:markdown_ignore_first)
   else
     return "="
   endif
@@ -100,6 +100,10 @@ endif
 
 if !exists('g:markdown_fold_override_foldtext')
   let g:markdown_fold_override_foldtext = 1
+endif
+
+if !exists('g:markdown_ignore_first')
+  let g:markdown_ignore_first = 0
 endif
 
 setlocal foldmethod=expr

--- a/doc/markdown-folding.txt
+++ b/doc/markdown-folding.txt
@@ -81,4 +81,8 @@ If set to 0, the fold text will not be overriden:>
     let g:markdown_fold_override_foldtext = 0
 <
 
+                                            *g:markdown_fold_override_foldtext*
+If set to 1, the first level headings will be ignored with nested folding:>
+let g:markdown_ignore_first = 0
+<
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
I find it annoying that with nested folding, the first level header is folded. I've added an option for my preferred behaviour.
